### PR TITLE
App insights location set to UK south

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "azurerm_key_vault_secret" "AZURE_APPINSIGHTS_KEY_PREVIEW" {
 
 resource "azurerm_application_insights" "appinsights_preview" {
   name                = "${var.product}-appinsights-preview"
-  location            = var.appinsights_location
+  location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
   application_type    = "web"
   count               = var.env == "aat" ? 1 : 0

--- a/variables.tf
+++ b/variables.tf
@@ -26,11 +26,6 @@ variable "jenkins_AAD_objectId" {
   description = "(Required) The Azure AD object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies."
 }
 
-variable "appinsights_location" {
-  default     = "West Europe"
-  description = "Location for Application Insights"
-}
-
 variable "custom_alerts_enabled" {
   description = "If set to true, enable alerts"
   default     = false


### PR DESCRIPTION
### Change description ###
Master build to upgrade REDIS instance from basic to premium is broken due to app insights preview location. It is supposed to be UK south like app insights location itself. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
