### PR TITLE
Add application-insights-access.tf

### DIFF
--- a/application-insights-access.tf
+++ b/application-insights-access.tf
@@ -1,0 +1,50 @@
+# Application Insights Access Management
+# This file manages external access to Application Insights for services that need to query logs
+
+data "azurerm_application_insights" "main" {
+  name                = module.application_insights.name
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+# Slack alerts function app needs to query Application Insights
+# Function app is in a different subscription, so we reference it by its managed identity principal ID
+# Only created in prod environment where the slack alerts function runs
+
+# Grant access to the Log Analytics Workspace (required for querying logs)
+resource "azurerm_role_assignment" "slack_alerts_monitoring_reader_workspace" {
+  count = var.env == "prod" ? 1 : 0
+
+  scope                = data.azurerm_application_insights.main.workspace_id
+  role_definition_name = "Monitoring Reader"
+  principal_id         = local.slack_alerts_principal_id
+
+  description = "Allows slack alerts function app to query Application Insights workspace using Azure AD authentication"
+}
+
+# Also grant access to the Application Insights resource itself
+resource "azurerm_role_assignment" "slack_alerts_monitoring_reader_appinsights" {
+  count = var.env == "prod" ? 1 : 0
+
+  scope                = data.azurerm_application_insights.main.id
+  role_definition_name = "Monitoring Reader"
+  principal_id         = local.slack_alerts_principal_id
+
+  description = "Allows slack alerts function app to read Application Insights metadata"
+}
+
+# Output workspace ID for use by services that need to query logs
+# Only created in prod where the slack alerts function needs it
+resource "azurerm_key_vault_secret" "app_insights_workspace_id" {
+  count = var.env == "prod" ? 1 : 0
+
+  name         = "app-insights-workspace-id"
+  value        = data.azurerm_application_insights.main.workspace_id
+  key_vault_id = module.key-vault.key_vault_id
+
+  tags = merge(
+    var.common_tags,
+    {
+      description = "Workspace ID for Azure AD authenticated queries to Application Insights"
+    }
+  )
+}

--- a/main.tf
+++ b/main.tf
@@ -114,3 +114,15 @@ resource "azurerm_key_vault_secret" "redis_access_key" {
 #  value        = module.prl-citizen-frontend-secondary-session-storage.access_key
 #  key_vault_id = data.azurerm_key_vault.key_vault.id
 #}
+
+# Slack alerts function app managed identity principal ID
+# Can be provided via variable or uses hardcoded default for prod
+# Hardcoded because pipeline service principal lacks access to subscription
+# If function app is recreated, update this ID from:
+# az functionapp identity show --name prl-slack-alerts --resource-group prl-slack-alerts --query principalId -o tsv
+locals {
+  # Use variable if provided, otherwise use hardcoded prod value
+  slack_alerts_principal_id = var.slack_alerts_principal_id != "" ? var.slack_alerts_principal_id : (
+    var.env == "prod" ? "98ec027e-40cb-49db-92de-6e7454ac5cc9" : null
+  )
+}

--- a/variables.tf
+++ b/variables.tf
@@ -44,3 +44,9 @@ variable "capacity" {
   default     = "1"
   description = "The size of the Redis cache to deploy. Valid values are 1, 2, 3, 4, 5"
 }
+
+variable "slack_alerts_principal_id" {
+  description = "Managed identity principal ID of the slack alerts function app. Only needed in prod."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/FPVTL-2181

### Change description
- Add Terraform file to manage access to Application Insights for the prl-slack-alerts function app so that it can query logs.
- Grants "Monitoring Reader" role to function app but only in the prod environment