### PR TITLE
Configure Application Insights telemetry sampling percentage

### DIFF
--- a/application-insights.tf
+++ b/application-insights.tf
@@ -8,6 +8,7 @@ module "application_insights" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = var.location
   common_tags         = var.common_tags
+  sampling_percentage = var.sampling_percentage
 }
 
 moved {

--- a/ithc.tfvars
+++ b/ithc.tfvars
@@ -1,2 +1,3 @@
 #this var for enabling monitoring alerts from main.tp per environment
 custom_alerts_enabled = "false"
+sampling_percentage = 1

--- a/ithc.tfvars
+++ b/ithc.tfvars
@@ -1,3 +1,3 @@
 #this var for enabling monitoring alerts from main.tp per environment
 custom_alerts_enabled = "false"
-sampling_percentage = 1
+sampling_percentage   = 1

--- a/perftest.tfvars
+++ b/perftest.tfvars
@@ -1,2 +1,3 @@
 #this var for enabling monitoring alerts from main.tp per environment
 custom_alerts_enabled = "false"
+sampling_percentage = 1

--- a/perftest.tfvars
+++ b/perftest.tfvars
@@ -1,3 +1,3 @@
 #this var for enabling monitoring alerts from main.tp per environment
 custom_alerts_enabled = "false"
-sampling_percentage = 1
+sampling_percentage   = 1

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,9 @@ variable "slack_alerts_principal_id" {
   type        = string
   default     = ""
 }
+
+variable "sampling_percentage" {
+  description = "Percentage of telemetry data sampled by Application Insights. Defaults to 100."
+  type        = number
+  default     = 100
+}


### PR DESCRIPTION
### Change description

- Configure Application Insights to sample 100% of telemetry data for  prod, aat, demo 
- and 1% for perftest and ithc
- This is required so that we override the default of 1% for aat and demo as set here: https://github.com/hmcts/terraform-module-application-insights/blob/2e4994f717b48456d3510f444bed77ad7b19ecd9/app-insights.tf#L5
